### PR TITLE
Fix ssh-keyscan with non default port

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,13 +9,13 @@ concurrency: ${{ github.workflow }}
 jobs:
   test:
     name: Test Action
-    if: ${{ secrets.SSH_HOST != '' && secrets.SSH_USER != '' && secrets.SSH_KEY != '' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - id: ssh
         name: Run action
+        if: ${{ secrets.SSH_HOST != '' && secrets.SSH_USER != '' && secrets.SSH_KEY != '' }}
         uses: ./
         with:
           SSH_HOST: ${{ secrets.SSH_HOST }}
@@ -23,20 +23,22 @@ jobs:
           SSH_KEY: ${{ secrets.SSH_KEY }}
 
       - name: Config file for debugging
+        if: ${{ steps.ssh.conclusion == 'success' }}
         run: cat ~/.ssh/config
 
       - name: Test
+        if: ${{ steps.ssh.conclusion == 'success' }}
         run: ssh -q ${{ steps.ssh.outputs.SERVER }} 'pwd && exit'
 
   test-bastion:
     name: Test Action (via bastion)
-    if: ${{ secrets.SSH_HOST != '' && secrets.SSH_USER != '' && secrets.SSH_KEY != '' && secrets.SSH_BASTION_HOST != '' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - id: ssh
         name: Run action with bastion
+        if: ${{ secrets.SSH_HOST != '' && secrets.SSH_USER != '' && secrets.SSH_KEY != '' && secrets.SSH_BASTION_HOST != '' }}
         uses: ./
         with:
           SSH_HOST: ${{ secrets.SSH_HOST }}
@@ -47,7 +49,9 @@ jobs:
           SSH_BASTION_KEY: ${{ secrets.SSH_BASTION_KEY }}
 
       - name: Config file for debugging
+        if: ${{ steps.ssh.conclusion == 'success' }}
         run: cat ~/.ssh/config
 
       - name: Test
+        if: ${{ steps.ssh.conclusion == 'success' }}
         run: ssh -q ${{ steps.ssh.outputs.SERVER }} 'pwd && exit'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,15 +9,42 @@ concurrency: ${{ github.workflow }}
 jobs:
   test:
     name: Test Action
+    if: ${{ secrets.SSH_HOST != '' && secrets.SSH_USER != '' && secrets.SSH_KEY != '' }}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - id: ssh
         name: Run action
-        uses: invi5H/ssh-action@main
+        uses: ./
         with:
           SSH_HOST: ${{ secrets.SSH_HOST }}
           SSH_USER: ${{ secrets.SSH_USER }}
           SSH_KEY: ${{ secrets.SSH_KEY }}
+
+      - name: Config file for debugging
+        run: cat ~/.ssh/config
+
+      - name: Test
+        run: ssh -q ${{ steps.ssh.outputs.SERVER }} 'pwd && exit'
+
+  test-bastion:
+    name: Test Action (via bastion)
+    if: ${{ secrets.SSH_HOST != '' && secrets.SSH_USER != '' && secrets.SSH_KEY != '' && secrets.SSH_BASTION_HOST != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: ssh
+        name: Run action with bastion
+        uses: ./
+        with:
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+          SSH_BASTION_HOST: ${{ secrets.SSH_BASTION_HOST }}
+          SSH_BASTION_USER: ${{ secrets.SSH_BASTION_USER }}
+          SSH_BASTION_KEY: ${{ secrets.SSH_BASTION_KEY }}
 
       - name: Config file for debugging
         run: cat ~/.ssh/config

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,12 +10,14 @@ jobs:
   test:
     name: Test Action
     runs-on: ubuntu-latest
+    env:
+      HAS_SSH_SECRETS: ${{ secrets.SSH_HOST != '' && secrets.SSH_USER != '' && secrets.SSH_KEY != '' }}
     steps:
       - uses: actions/checkout@v4
 
       - id: ssh
         name: Run action
-        if: ${{ secrets.SSH_HOST != '' && secrets.SSH_USER != '' && secrets.SSH_KEY != '' }}
+        if: ${{ env.HAS_SSH_SECRETS == 'true' }}
         uses: ./
         with:
           SSH_HOST: ${{ secrets.SSH_HOST }}
@@ -33,12 +35,14 @@ jobs:
   test-bastion:
     name: Test Action (via bastion)
     runs-on: ubuntu-latest
+    env:
+      HAS_BASTION_SECRETS: ${{ secrets.SSH_HOST != '' && secrets.SSH_USER != '' && secrets.SSH_KEY != '' && secrets.SSH_BASTION_HOST != '' }}
     steps:
       - uses: actions/checkout@v4
 
       - id: ssh
         name: Run action with bastion
-        if: ${{ secrets.SSH_HOST != '' && secrets.SSH_USER != '' && secrets.SSH_KEY != '' && secrets.SSH_BASTION_HOST != '' }}
+        if: ${{ env.HAS_BASTION_SECRETS == 'true' }}
         uses: ./
         with:
           SSH_HOST: ${{ secrets.SSH_HOST }}

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: ssh
-        uses: ./ # or your-org/ssh-action@v1
+        uses: kuuak/ssh-action@main
         with:
           SSH_HOST: ${{ secrets.SSH_HOST }}
           SSH_PORT: "22"
@@ -55,7 +55,7 @@ If the bastion uses a **different** key than the final host, set `SSH_BASTION_KE
 
 ```yaml
       - id: ssh
-        uses: ./
+        uses: kuuak/ssh-action@main
         with:
           NAME: prod
           SSH_HOST: ${{ secrets.SSH_HOST }}
@@ -74,7 +74,7 @@ Run the action once per server with a **unique** `NAME` each time.
 
 ```yaml
       - id: ssh-foo
-        uses: ./
+        uses: kuuak/ssh-action@main
         with:
           NAME: foo
           SSH_HOST: ${{ secrets.FOO_HOST }}
@@ -82,7 +82,7 @@ Run the action once per server with a **unique** `NAME` each time.
           SSH_USER: ${{ secrets.FOO_USER }}
           SSH_KEY: ${{ secrets.FOO_KEY }}
       - id: ssh-bar
-        uses: ./
+        uses: kuuak/ssh-action@main
         with:
           NAME: bar
           SSH_HOST: ${{ secrets.BAR_HOST }}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,32 @@
 # SSH Action
-A github action to setup ssh key and config in the current environment.
 
-# Usage
-```
+A GitHub Action that writes a private key under `~/.ssh/`, appends host keys to `~/.ssh/known_hosts`, and adds a `Host` entry to `~/.ssh/config` so you can run `ssh` against your server from the workflow.
+
+## Inputs
+
+| Input | Required | Default | Description |
+|--------|----------|---------|-------------|
+| `NAME` | No | `server` | Unique label for this server. Slugified (lowercase, safe characters) and used as the SSH config `Host` alias. |
+| `SSH_USER` | Yes | — | SSH username for the **target** host. |
+| `SSH_HOST` | Yes | — | Hostname or IP of the **target** host. |
+| `SSH_PORT` | No | `22` | SSH port on the target. |
+| `SSH_KEY` | Yes | — | Full PEM/OpenSSH private key string for the **target** host. |
+| `SSH_BASTION_HOST` | No | — | If set, connect via a bastion/jump host using `ProxyJump`. |
+| `SSH_BASTION_USER` | No | same as `SSH_USER` | SSH username on the bastion (only used when `SSH_BASTION_HOST` is set). |
+| `SSH_BASTION_PORT` | No | `22` | SSH port on the bastion. |
+| `SSH_BASTION_KEY` | No | — | Optional separate private key for the bastion when it differs from `SSH_KEY`. If omitted, the bastion entry has no `IdentityFile` line; SSH may use the agent or default keys. |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `SERVER` | The `Host` alias written to `~/.ssh/config` (derived from `NAME`). Use as `ssh ${{ steps.<id>.outputs.SERVER }} …`. |
+
+## Usage
+
+### Direct connection
+
+```yaml
 name: ssh command
 on: push
 jobs:
@@ -10,37 +34,58 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: ssh
-        uses: invi5H/ssh-action@v1
+        uses: ./ # or your-org/ssh-action@v1
         with:
           SSH_HOST: ${{ secrets.SSH_HOST }}
-          SSH_PORT: ${{ secrets.SSH_PORT }}
+          SSH_PORT: "22"
           SSH_USER: ${{ secrets.SSH_USER }}
           SSH_KEY: ${{ secrets.SSH_KEY }}
       - run: ssh ${{ steps.ssh.outputs.SERVER }} pwd
 ```
 
-For multiple servers, run the above action multiple times, with a unique lowercase name each time
+### Bastion / jump host
+
+When `SSH_BASTION_HOST` is set, the action:
+
+1. Runs `ssh-keyscan` for both the bastion and the target host.
+2. Adds a `Host <name>-bastion` entry for the jump host.
+3. Adds `ProxyJump <name>-bastion` on the target `Host <name>` entry.
+
+If the bastion uses a **different** key than the final host, set `SSH_BASTION_KEY`. The bastion entry then uses `IdentityFile` for that key; the target still uses `SSH_KEY`.
+
+```yaml
+      - id: ssh
+        uses: ./
+        with:
+          NAME: prod
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+          SSH_BASTION_HOST: ${{ secrets.BASTION_HOST }}
+          SSH_BASTION_USER: ${{ secrets.BASTION_USER }}
+          SSH_BASTION_PORT: "22"
+          SSH_BASTION_KEY: ${{ secrets.BASTION_SSH_KEY }}
+      - run: ssh ${{ steps.ssh.outputs.SERVER }} 'hostname'
 ```
-name: ssh command
-on: push
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
+
+### Multiple servers
+
+Run the action once per server with a **unique** `NAME` each time.
+
+```yaml
       - id: ssh-foo
-        uses: invi5H/ssh-action@v1
+        uses: ./
         with:
           NAME: foo
           SSH_HOST: ${{ secrets.FOO_HOST }}
-          SSH_PORT: ${{ secrets.FOO_PORT }}
+          SSH_PORT: "22"
           SSH_USER: ${{ secrets.FOO_USER }}
           SSH_KEY: ${{ secrets.FOO_KEY }}
       - id: ssh-bar
-        uses: invi5H/ssh-action@v1
+        uses: ./
         with:
           NAME: bar
           SSH_HOST: ${{ secrets.BAR_HOST }}
-          SSH_PORT: ${{ secrets.BAR_PORT }}
           SSH_USER: ${{ secrets.BAR_USER }}
           SSH_KEY: ${{ secrets.BAR_KEY }}
       - run: ssh ${{ steps.ssh-foo.outputs.SERVER }} pwd

--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ If the bastion uses a **different** key than the final host, set `SSH_BASTION_KE
           SSH_HOST: ${{ secrets.SSH_HOST }}
           SSH_USER: ${{ secrets.SSH_USER }}
           SSH_KEY: ${{ secrets.SSH_KEY }}
-          SSH_BASTION_HOST: ${{ secrets.BASTION_HOST }}
-          SSH_BASTION_USER: ${{ secrets.BASTION_USER }}
+          SSH_BASTION_HOST: ${{ secrets.SSH_BASTION_HOST }}
+          SSH_BASTION_USER: ${{ secrets.SSH_BASTION_USER }}
           SSH_BASTION_PORT: "22"
-          SSH_BASTION_KEY: ${{ secrets.BASTION_SSH_KEY }}
+          SSH_BASTION_KEY: ${{ secrets.SSH_BASTION_KEY }}
       - run: ssh ${{ steps.ssh.outputs.SERVER }} 'hostname'
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ runs:
         sudo chmod 600 ~/.ssh/${{ steps.setup.outputs.name }}.key
       shell: bash
     - name: Scan the public ssh host keys
-      run: ssh-keyscan -H ${{ inputs.SSH_HOST }} >> ~/.ssh/known_hosts
+      run: ssh-keyscan -p ${{ inputs.SSH_PORT }} -H ${{ inputs.SSH_HOST }} >> ~/.ssh/known_hosts
       shell: bash
     - name: Create SSH config
       run: |

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,9 @@ inputs:
   SSH_BASTION_HOST:
     description: "Optional bastion/jump host (hostname or IP)"
     required: false
+  SSH_BASTION_KEY:
+    description: "Optional private key for bastion/jump host (if different from SSH_KEY)"
+    required: false
   SSH_BASTION_PORT:
     description: "Optional bastion/jump port"
     required: false
@@ -51,6 +54,14 @@ runs:
         echo "${{ inputs.SSH_KEY }}" > ~/.ssh/${{ steps.setup.outputs.name }}.key
         sudo chmod 600 ~/.ssh/${{ steps.setup.outputs.name }}.key
       shell: bash
+    - name: Create bastion SSH key (optional)
+      run: |
+        if [[ -n "${{ inputs.SSH_BASTION_KEY }}" ]]; then
+          mkdir -p ~/.ssh/
+          echo "${{ inputs.SSH_BASTION_KEY }}" > ~/.ssh/${{ steps.setup.outputs.name }}.bastion.key
+          sudo chmod 600 ~/.ssh/${{ steps.setup.outputs.name }}.bastion.key
+        fi
+      shell: bash
     - name: Scan the public ssh host keys
       run: |
         ssh-keyscan -p "${{ inputs.SSH_PORT }}" -H "${{ inputs.SSH_HOST }}" >> ~/.ssh/known_hosts
@@ -64,12 +75,23 @@ runs:
         BASTION_HOST="${{ inputs.SSH_BASTION_HOST }}"
         BASTION_USER="${{ inputs.SSH_BASTION_USER }}"
         BASTION_PORT="${{ inputs.SSH_BASTION_PORT }}"
+        BASTION_KEY_PRESENT="${{ inputs.SSH_BASTION_KEY }}"
 
         if [[ -z "$BASTION_USER" ]]; then
           BASTION_USER="${{ inputs.SSH_USER }}"
         fi
 
         {
+          if [[ -n "$BASTION_HOST" ]]; then
+            echo "Host ${{ steps.setup.outputs.name }}-bastion"
+            echo "  HostName ${BASTION_HOST}"
+            echo "  Port ${BASTION_PORT}"
+            echo "  User ${BASTION_USER}"
+            if [[ -n "$BASTION_KEY_PRESENT" ]]; then
+              echo "  IdentityFile ~/.ssh/${{ steps.setup.outputs.name }}.bastion.key"
+            fi
+          fi
+
           echo "Host ${{ steps.setup.outputs.name }}"
           echo "  HostName ${{ inputs.SSH_HOST }}"
           echo "  Port ${{ inputs.SSH_PORT }}"
@@ -77,7 +99,7 @@ runs:
           echo "  IdentityFile ~/.ssh/${{ steps.setup.outputs.name }}.key"
 
           if [[ -n "$BASTION_HOST" ]]; then
-            echo "  ProxyJump ${BASTION_USER}@${BASTION_HOST}:${BASTION_PORT}"
+            echo "  ProxyJump ${{ steps.setup.outputs.name }}-bastion"
           fi
         } >> ~/.ssh/config
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,16 @@ inputs:
   SSH_KEY:
     description: "The full string SSH key"
     required: true
+  SSH_BASTION_USER:
+    description: "Optional SSH username for bastion/jump host"
+    required: false
+  SSH_BASTION_HOST:
+    description: "Optional bastion/jump host (hostname or IP)"
+    required: false
+  SSH_BASTION_PORT:
+    description: "Optional bastion/jump port"
+    required: false
+    default: "22"
 
 outputs:
   SERVER:
@@ -42,17 +52,34 @@ runs:
         sudo chmod 600 ~/.ssh/${{ steps.setup.outputs.name }}.key
       shell: bash
     - name: Scan the public ssh host keys
-      run: ssh-keyscan -p ${{ inputs.SSH_PORT }} -H ${{ inputs.SSH_HOST }} >> ~/.ssh/known_hosts
+      run: |
+        ssh-keyscan -p "${{ inputs.SSH_PORT }}" -H "${{ inputs.SSH_HOST }}" >> ~/.ssh/known_hosts
+
+        if [[ -n "${{ inputs.SSH_BASTION_HOST }}" ]]; then
+          ssh-keyscan -p "${{ inputs.SSH_BASTION_PORT }}" -H "${{ inputs.SSH_BASTION_HOST }}" >> ~/.ssh/known_hosts
+        fi
       shell: bash
     - name: Create SSH config
       run: |
-        cat >>~/.ssh/config <<END
-        Host ${{ steps.setup.outputs.name }}
-          HostName ${{ inputs.SSH_HOST }}
-          Port ${{ inputs.SSH_PORT }}
-          User ${{ inputs.SSH_USER }}
-          IdentityFile ~/.ssh/${{ steps.setup.outputs.name }}.key
-        END
+        BASTION_HOST="${{ inputs.SSH_BASTION_HOST }}"
+        BASTION_USER="${{ inputs.SSH_BASTION_USER }}"
+        BASTION_PORT="${{ inputs.SSH_BASTION_PORT }}"
+
+        if [[ -z "$BASTION_USER" ]]; then
+          BASTION_USER="${{ inputs.SSH_USER }}"
+        fi
+
+        {
+          echo "Host ${{ steps.setup.outputs.name }}"
+          echo "  HostName ${{ inputs.SSH_HOST }}"
+          echo "  Port ${{ inputs.SSH_PORT }}"
+          echo "  User ${{ inputs.SSH_USER }}"
+          echo "  IdentityFile ~/.ssh/${{ steps.setup.outputs.name }}.key"
+
+          if [[ -n "$BASTION_HOST" ]]; then
+            echo "  ProxyJump ${BASTION_USER}@${BASTION_HOST}:${BASTION_PORT}"
+          fi
+        } >> ~/.ssh/config
       shell: bash
 
 branding:

--- a/action.yml
+++ b/action.yml
@@ -93,6 +93,8 @@ runs:
             echo "  User ${BASTION_USER}"
             if [[ -n "$BASTION_KEY_PRESENT" ]]; then
               echo "  IdentityFile ~/.ssh/${{ steps.setup.outputs.name }}.bastion.key"
+            else
+              echo "  IdentityFile ~/.ssh/${{ steps.setup.outputs.name }}.key"
             fi
           fi
 

--- a/action.yml
+++ b/action.yml
@@ -104,6 +104,8 @@ runs:
 
           if [[ -n "$BASTION_HOST" ]]; then
             echo "  ProxyJump ${{ steps.setup.outputs.name }}-bastion"
+            # Target may only be reachable via bastion; accept its host key automatically on first connect.
+            echo "  StrictHostKeyChecking accept-new"
           fi
         } >> ~/.ssh/config
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -52,22 +52,26 @@ runs:
       run: |
         mkdir -p ~/.ssh/
         echo "${{ inputs.SSH_KEY }}" > ~/.ssh/${{ steps.setup.outputs.name }}.key
-        sudo chmod 600 ~/.ssh/${{ steps.setup.outputs.name }}.key
+        chmod 600 ~/.ssh/${{ steps.setup.outputs.name }}.key
       shell: bash
     - name: Create bastion SSH key (optional)
       run: |
         if [[ -n "${{ inputs.SSH_BASTION_KEY }}" ]]; then
           mkdir -p ~/.ssh/
           echo "${{ inputs.SSH_BASTION_KEY }}" > ~/.ssh/${{ steps.setup.outputs.name }}.bastion.key
-          sudo chmod 600 ~/.ssh/${{ steps.setup.outputs.name }}.bastion.key
+          chmod 600 ~/.ssh/${{ steps.setup.outputs.name }}.bastion.key
         fi
       shell: bash
     - name: Scan the public ssh host keys
       run: |
-        ssh-keyscan -p "${{ inputs.SSH_PORT }}" -H "${{ inputs.SSH_HOST }}" >> ~/.ssh/known_hosts
-
-        if [[ -n "${{ inputs.SSH_BASTION_HOST }}" ]]; then
-          ssh-keyscan -p "${{ inputs.SSH_BASTION_PORT }}" -H "${{ inputs.SSH_BASTION_HOST }}" >> ~/.ssh/known_hosts
+        # When no bastion is configured, fail on ssh-keyscan errors (current behavior).
+        if [[ -z "${{ inputs.SSH_BASTION_HOST }}" ]]; then
+          ssh-keyscan -p "${{ inputs.SSH_PORT }}" -H "${{ inputs.SSH_HOST }}" >> ~/.ssh/known_hosts
+        else
+          # When using a bastion, the target host may not be reachable from the runner.
+          # Make ssh-keyscan best-effort to avoid failing the action in that case.
+          ssh-keyscan -p "${{ inputs.SSH_PORT }}" -H "${{ inputs.SSH_HOST }}" >> ~/.ssh/known_hosts || true
+          ssh-keyscan -p "${{ inputs.SSH_BASTION_PORT }}" -H "${{ inputs.SSH_BASTION_HOST }}" >> ~/.ssh/known_hosts || true
         fi
       shell: bash
     - name: Create SSH config


### PR DESCRIPTION
`ssh-keyscan` was failling because our remote hosting server is not using default port number.

This PR fixes it by seting the port number with -p option on `ssh-keyscan`
